### PR TITLE
Fix user register role slugs

### DIFF
--- a/app/Http/Controllers/Auth/ActivateController.php
+++ b/app/Http/Controllers/Auth/ActivateController.php
@@ -149,7 +149,7 @@ class ActivateController extends Controller
         $user           = Auth::user();
         $currentRoute   = Route::currentRouteName();
         $ipAddress      = new CaptureIpTrait;
-        $role           = Role::where('name', '=', 'user')->first();
+        $role           = Role::where('slug', '=', 'user')->first();
         $profile        = new Profile;
 
         $rCheck = $this->activeRedirect($user, $currentRoute);

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -98,7 +98,7 @@ class RegisterController extends Controller {
 	protected function create(array $data) {
 
 		$ipAddress = new CaptureIpTrait;
-		$role      = Role::where('name', '=', 'Unverified')->first();
+		$role      = Role::where('slug', '=', 'unverified')->first();
 
 		$user = User::create([
 				'name'              => $data['name'],

--- a/app/Http/Controllers/Auth/SocialController.php
+++ b/app/Http/Controllers/Auth/SocialController.php
@@ -74,7 +74,7 @@ class SocialController extends Controller
                 $ipAddress  = new CaptureIpTrait;
                 $socialData = new Social;
                 $profile    = new Profile;
-                $role       = Role::where('name', '=', 'user')->first();
+                $role       = Role::where('slug', '=', 'user')->first();
                 $fullname   = explode(' ', $socialUserObject->name);
 
                 $username = $socialUserObject->nickname;

--- a/database/seeds/ConnectRelationshipsSeeder.php
+++ b/database/seeds/ConnectRelationshipsSeeder.php
@@ -26,7 +26,7 @@ class ConnectRelationshipsSeeder extends Seeder
 	     * Attach Permissions to Roles
 	     *
 	     */
-		$roleAdmin = Role::where('name', '=', 'Admin')->first();
+		$roleAdmin = Role::where('slug', '=', 'admin')->first();
 		foreach ($permissions as $permission) {
 			$roleAdmin->attachPermission($permission);
 		}

--- a/database/seeds/RolesTableSeeder.php
+++ b/database/seeds/RolesTableSeeder.php
@@ -19,7 +19,7 @@ class RolesTableSeeder extends Seeder
 	     * Add Roles
 	     *
 	     */
-    	if (Role::where('name', '=', 'Admin')->first() === null) {
+    	if (Role::where('slug', '=', 'admin')->first() === null) {
 	        $adminRole = Role::create([
 	            'name' => 'Admin',
 	            'slug' => 'admin',
@@ -28,7 +28,7 @@ class RolesTableSeeder extends Seeder
         	]);
 	    }
 
-    	if (Role::where('name', '=', 'User')->first() === null) {
+    	if (Role::where('slug', '=', 'user')->first() === null) {
 	        $userRole = Role::create([
 	            'name' => 'User',
 	            'slug' => 'user',
@@ -37,7 +37,7 @@ class RolesTableSeeder extends Seeder
 	        ]);
 	    }
 
-    	if (Role::where('name', '=', 'Unverified')->first() === null) {
+    	if (Role::where('slug', '=', 'unverified')->first() === null) {
 	        $userRole = Role::create([
 	            'name' => 'Unverified',
 	            'slug' => 'unverified',


### PR DESCRIPTION
When activating a new user, their Role is not set properly. The `name` column is capitalized, so when using sqlite at least, it is case sensitive and doesn't match "User", leaving the newly-activated user without a valid Role associated.

Here I suggest using the slug as it should always be consistently-lowercased and thus more reliable.