### PR TITLE
Update SocialController.php

### DIFF
--- a/app/Http/Controllers/Auth/SocialController.php
+++ b/app/Http/Controllers/Auth/SocialController.php
@@ -76,7 +76,8 @@ class SocialController extends Controller
                 $profile    = new Profile;
                 $role       = Role::where('slug', '=', 'user')->first();
                 $fullname   = explode(' ', $socialUserObject->name);
-
+                if(count($fullname)==1)
+                    $fullname[1]='';
                 $username = $socialUserObject->nickname;
 
                 if ($username == null) {


### PR DESCRIPTION
#### provider like github my return null value for `$socialUserObject->name`
so line 78 will make `$fullname[0]=''` and we do not have `$fullname[1]` it 's ok to make (first_name) and (last_name) accept null value
 but it's not ok to access `$fullname[1]` in this line `'last_name'`  => `$fullname[1],` that will cause undefined index error.