### PR TITLE
asset function added to asset publication

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -23,7 +23,7 @@
         @yield('template_linked_fonts')
 
         {{-- Styles --}}
-        <link href="{{ mix('/css/app.css') }}" rel="stylesheet">
+        <link href="{{ asset(mix('/css/app.css')) }}" rel="stylesheet">
 
         @yield('template_linked_css')
 
@@ -69,7 +69,7 @@
         </div>
 
         {{-- Scripts --}}
-        <script src="{{ mix('/js/app.js') }}"></script>
+        <script src="{{ asset(mix('/js/app.js')) }}"></script>
         {!! HTML::script('//maps.googleapis.com/maps/api/js?key='.env("GOOGLEMAPS_API_KEY").'&libraries=places&dummy=.js', array('type' => 'text/javascript')) !!}
 
         @yield('footer_scripts')


### PR DESCRIPTION
Without the help of `asset()` function the url to asset formed is `http://localhost/js/app.3d31ff07b421b5b58842.js`

And with the help of asset() function like in
`<script src="{{ asset(mix('/js/app.js')) }}"></script>`
the url to asset formed is
`http://localhost/proj/public/js/app.3d31ff07b421b5b58842.js`