### PR TITLE
User profile edit form field for github user name use correct placeholder text.

### DIFF
--- a/resources/views/profiles/edit.blade.php
+++ b/resources/views/profiles/edit.blade.php
@@ -173,7 +173,7 @@
 											<div class="margin-bottom-2 form-group has-feedback {{ $errors->has('github_username') ? ' has-error ' : '' }}">
 												{!! Form::label('github_username', trans('profile.label-github_username') , array('class' => 'col-sm-4 control-label')); !!}
 												<div class="col-sm-6">
-													{!! Form::text('github_username', old('github_username'), array('id' => 'github_username', 'class' => 'form-control', 'placeholder' => trans('profile.ph-twitter_username'))) !!}
+													{!! Form::text('github_username', old('github_username'), array('id' => 'github_username', 'class' => 'form-control', 'placeholder' => trans('profile.ph-github_username'))) !!}
 													<span class="glyphicon glyphicon-pencil form-control-feedback" aria-hidden="true"></span>
 											        @if ($errors->has('github_username'))
 											            <span class="help-block">


### PR DESCRIPTION
On the **/profile/brooklyn.lockman/edit** profile page, the "**Your GitHub username:**" field had "_Enter your Twitter username_" as placeholder text. Fixed it to use the github placeholder text instead.