### PR TITLE
Users created by admin and left as unverified have no activations to show.

### DIFF
--- a/app/Http/Controllers/Auth/ActivateController.php
+++ b/app/Http/Controllers/Auth/ActivateController.php
@@ -123,7 +123,7 @@ class ActivateController extends Controller
 
         $data = [
             'email' => $user->email,
-            'date'  => $lastActivation->created_at->format('m/d/Y'), //
+            'date'  => $lastActivation ? $lastActivation->created_at->format('m/d/Y') : null, //
         ];
 
         return view($this->getActivationView())->with($data);


### PR DESCRIPTION
If an admin user creates a new user but leaves it as unverified, the user cannot get to the resend activation email page because there are no existing activations.

A proper fix might be to send it when an admin creates the user (but that seems unnecessarily convoluted) or change the view to show different text when there is no activation email yet.

Proposing this as a tentative quick-fix.