### PR TITLE
Prefer to use config settings in application code over `env()` calls due to Laravel configuration caching.

### DIFF
--- a/app/Http/Controllers/UsersManagementController.php
+++ b/app/Http/Controllers/UsersManagementController.php
@@ -30,7 +30,7 @@ class UsersManagementController extends Controller
      */
     public function index()
     {
-        $users = User::paginate(env('USER_LIST_PAGINATION_SIZE'));
+        $users = User::paginate(config('settings.userListPaginationSize'));
         $roles = Role::all();
 
         return View('usersmanagement.show-users', compact('users', 'roles'));

--- a/app/Traits/CaptchaTrait.php
+++ b/app/Traits/CaptchaTrait.php
@@ -11,7 +11,7 @@ trait CaptchaTrait
     {
         $response = Input::get('g-recaptcha-response');
         $remoteip = $_SERVER['REMOTE_ADDR'];
-        $secret = env('RE_CAP_SECRET');
+        $secret = config('settings.reCaptchSecret');
 
         $recaptcha = new ReCaptcha($secret);
         $resp = $recaptcha->verify($response, $remoteip);

--- a/config/settings.php
+++ b/config/settings.php
@@ -50,7 +50,7 @@ return [
     /*
      * ReCaptcha Site Key
      */
-    'reCaptchSite'   => env('RE_CAP_SITE',   'YOURGOOGLECAPTCHAsitekeyHERE'),
+    'reCaptchSite'   => env('RE_CAP_SITE', 'YOURGOOGLECAPTCHAsitekeyHERE'),
 
     /*
      * ReCaptcha Secret
@@ -65,6 +65,6 @@ return [
     /*
      * Google Maps API Key
      */
-    'googleMapsAPIKey'    => env('GOOGLEMAPS_API_KEY',    'YOURGOOGLEMAPSkeyHERE'),
+    'googleMapsAPIKey'    => env('GOOGLEMAPS_API_KEY', 'YOURGOOGLEMAPSkeyHERE'),
 
 ];

--- a/config/settings.php
+++ b/config/settings.php
@@ -33,6 +33,11 @@ return [
     'restoreUserCutoff' => env('USER_RESTORE_CUTOFF_DAYS', 31),
 
     /*
+     * User list pagination size
+     */
+    'userListPaginationSize' => env('USER_LIST_PAGINATION_SIZE', 50),
+
+    /*
      * User restore encryption key
      */
     'restoreKey' => env('USER_RESTORE_ENCRYPTION_KEY', 'sup3rS3cr3tR35t0r3K3y21!'),
@@ -43,8 +48,23 @@ return [
     'reCaptchStatus' => env('ENABLE_RECAPTCHA', false),
 
     /*
+     * ReCaptcha Site Key
+     */
+    'reCaptchSite'   => env('RE_CAP_SITE',   'YOURGOOGLECAPTCHAsitekeyHERE'),
+
+    /*
+     * ReCaptcha Secret
+     */
+    'reCaptchSecret' => env('RE_CAP_SECRET', 'YOURGOOGLECAPTCHAsecretHERE'),
+
+    /*
      * Google Maps API V3 Status
      */
     'googleMapsAPIStatus' => env('GOOGLEMAPS_API_STATUS', false),
+
+    /*
+     * Google Maps API Key
+     */
+    'googleMapsAPIKey'    => env('GOOGLEMAPS_API_KEY',    'YOURGOOGLEMAPSkeyHERE'),
 
 ];

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -82,7 +82,7 @@
                         @if(config('settings.reCaptchStatus'))
                             <div class="form-group">
                                 <div class="col-sm-6 col-sm-offset-4">
-                                    <div class="g-recaptcha" data-sitekey="{{ env('RE_CAP_SITE') }}"></div>
+                                    <div class="g-recaptcha" data-sitekey="{{ config('settings.reCaptchSite') }}"></div>
                                 </div>
                             </div>
                         @endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -72,7 +72,7 @@
         <script src="{{ mix('/js/app.js') }}"></script>
 
         @if(config('settings.googleMapsAPIStatus'))
-            {!! HTML::script('//maps.googleapis.com/maps/api/js?key='.env("GOOGLEMAPS_API_KEY").'&libraries=places&dummy=.js', array('type' => 'text/javascript')) !!}
+            {!! HTML::script('//maps.googleapis.com/maps/api/js?key='.config("settings.googleMapsAPIKey").'&libraries=places&dummy=.js', array('type' => 'text/javascript')) !!}
         @endif
 
         @yield('footer_scripts')


### PR DESCRIPTION
Minor configuration cleanup to be compatible with `php artisan config:cache` if I understand it correctly after coming over this:

* https://github.com/laravel/framework/issues/19820#issuecomment-311942958

NOTE: Not tested in any way or form; changes only taken verbatim from a project I am working on, and changed a few other `env()` calls I noticed on the way. Adding PR in case it might be useful and the "right way" to do settings like this.