### PR TITLE
Should fix registered user count

### DIFF
--- a/resources/assets/js/components/UsersCount.vue
+++ b/resources/assets/js/components/UsersCount.vue
@@ -18,9 +18,10 @@
 <script>
     import Chart from 'chart.js'
     export default {
+        props: ['registered'],
         data() {
             return {
-                count: 0,
+                count: this.registered,
                 labels: ['Online']
             }
         },


### PR DESCRIPTION
This graph should be renamed to be "Total Registered Users" as "User::count()" is the total number of entries in the "user" table. Unless there is a way you can work out if users are actually logged on. 
ie. if there is a session timeout, then a date based token can be used, then a call to "User::active()" could return only those with token dates less then session timeout.
Just an idea.