### PR TITLE
Fix of incorrect comparison

### DIFF
--- a/app/Http/Controllers/Auth/ActivateController.php
+++ b/app/Http/Controllers/Auth/ActivateController.php
@@ -107,7 +107,7 @@ class ActivateController extends Controller
                 ->where('created_at', '>=', Carbon::now()->subHours(config('settings.timePeriod')))
                 ->count();
 
-            if ($activationsCount > config('settings.timePeriod')) {
+            if ($activationsCount > config('settings.maxAttempts')) {
                 Log::info('Exceded max resends in last '.config('settings.timePeriod').' hours. '.$currentRoute.'. ', [$user]);
 
                 $data = [


### PR DESCRIPTION
Makes the activationRequired method check maxAttempts against the activation count instead of incorrectly checking timePeriod.