### PR TITLE
Dev request patch update to use Request facade and class in place of Input::

### DIFF
--- a/app/Http/Controllers/Auth/SocialController.php
+++ b/app/Http/Controllers/Auth/SocialController.php
@@ -9,7 +9,7 @@ use App\Models\User;
 use App\Traits\ActivationTrait;
 use App\Traits\CaptureIpTrait;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Input;
+use Illuminate\Http\Request;
 use jeremykenedy\LaravelRoles\Models\Role;
 use Laravel\Socialite\Facades\Socialite;
 
@@ -43,9 +43,9 @@ class SocialController extends Controller
      *
      * @return Redirect
      */
-    public function getSocialHandle($provider)
+    public function getSocialHandle($provider, Request $request)
     {
-        if (Input::get('denied') != '') {
+        if ($request->get('denied') != '') {
             return redirect()->to('login')
                 ->with('status', 'danger')
                 ->with('message', trans('socials.denied'));

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -120,7 +120,7 @@ class ProfilesController extends Controller
     {
         $user = $this->getUserByUsername($username);
 
-        $input = Input::only('theme_id', 'location', 'bio', 'twitter_username', 'github_username', 'avatar_status');
+        $input = $request->only('theme_id', 'location', 'bio', 'twitter_username', 'github_username', 'avatar_status');
 
         $ipAddress = new CaptureIpTrait();
 

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -230,11 +230,11 @@ class ProfilesController extends Controller
      *
      * @return mixed
      */
-    public function upload()
+    public function upload(Request $request)
     {
-        if (Input::hasFile('file')) {
+        if ($request->hasFile('file')) {
             $currentUser = \Auth::user();
-            $avatar = Input::file('file');
+            $avatar = $request->file('file');
             $filename = 'avatar.'.$avatar->getClientOriginalExtension();
             $save_path = storage_path().'/users/id/'.$currentUser->id.'/uploads/images/avatar/';
             $path = $save_path.$filename;

--- a/app/Http/Controllers/ThemesManagementController.php
+++ b/app/Http/Controllers/ThemesManagementController.php
@@ -53,7 +53,7 @@ class ThemesManagementController extends Controller
      */
     public function store(Request $request)
     {
-        $input = Input::only('name', 'link', 'notes', 'status');
+        $input = $request->only('name', 'link', 'notes', 'status');
 
         $validator = Validator::make($input, Theme::rules());
 
@@ -142,7 +142,7 @@ class ThemesManagementController extends Controller
     {
         $theme = Theme::find($id);
 
-        $input = Input::only('name', 'link', 'notes', 'status');
+        $input = $request->only('name', 'link', 'notes', 'status');
 
         $validator = Validator::make($input, Theme::rules($id));
 

--- a/app/Traits/CaptchaTrait.php
+++ b/app/Traits/CaptchaTrait.php
@@ -2,14 +2,14 @@
 
 namespace App\Traits;
 
-use Illuminate\Support\Facades\Input;
+use Request;
 use ReCaptcha\ReCaptcha;
 
 trait CaptchaTrait
 {
     public function captchaCheck()
     {
-        $response = Input::get('g-recaptcha-response');
+        $response = Request::get('g-recaptcha-response');
         $remoteip = $_SERVER['REMOTE_ADDR'];
         $secret = config('settings.reCaptchSecret');
 


### PR DESCRIPTION
Hi Jeremy awesome work!

Updated controllers and 1 trait to use Laravel 6 Request facade and class to replace the removed
`Illuminate\Support\Facades\Input;`
All methods are now in the Request facade and class.
See https://laravel.com/docs/6.x/upgrade#the-input-facade

You will see I favour dependicy injection rather than facade classes but either will prob work ok.

Cheers, Tom.