### PR TITLE
Added ext-intl required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
+        "ext-intl": "*",
         "creativeorange/gravatar": "^1.0",
         "doctrine/dbal": "^2.9",
         "fideloper/proxy": "^4.0",


### PR DESCRIPTION
You have to accept this, It will stop error Class 'Locale' not found.

composer update will throw error if developer dont have php init extension installed on server.