### PR TITLE
'/exceeded' fixed

### DIFF
--- a/app/Http/Controllers/Auth/ActivateController.php
+++ b/app/Http/Controllers/Auth/ActivateController.php
@@ -294,8 +294,6 @@ class ActivateController extends Controller
             return view('auth.exceeded')->with($data);
         }
 
-        return $this->activeRedirect($user, $currentRoute)
-            ->with('status', 'info')
-            ->with('message', trans('auth.alreadyActivated'));
+        return redirect()->route(self::getActivationRoute());
     }
 }


### PR DESCRIPTION
'/exceeded' goes error when visited directly, if the user doesn't verify his email and also doesn't reach the sending limit.