### PR TITLE
Add 'Commands' directory scan for artisan commands

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -37,6 +37,8 @@ class Kernel extends ConsoleKernel
      */
     protected function commands()
     {
+        $this->load(__DIR__.'/Commands');
+
         require base_path('routes/console.php');
     }
 }


### PR DESCRIPTION
This is part of Laravel8, it should also be in your codebase as it automatically adds artisan jobs defined in app/Console/Commands to the list of recognized artisan commands. 