### PR TITLE
Issue #446 Fix to ensure $('#confirmSave').on('show.bs.modal', function (e) {...…

### DIFF
--- a/resources/views/scripts/save-modal-script.blade.php
+++ b/resources/views/scripts/save-modal-script.blade.php
@@ -1,16 +1,16 @@
 <script type="text/javascript">
-
 	// CONFIRMATION SAVE MODEL
-	$('#confirmSave').on('show.bs.modal', function (e) {
-		var message = $(e.relatedTarget).attr('data-message');
-		var title = $(e.relatedTarget).attr('data-title');
-		var form = $(e.relatedTarget).closest('form');
-		$(this).find('.modal-body p').text(message);
-		$(this).find('.modal-title').text(title);
-		$(this).find('.modal-footer #confirm').data('form', form);
-	});
-	$('#confirmSave').find('.modal-footer #confirm').on('click', function(){
-	  	$(this).data('form').submit();
-	});
-
+    $(document).ready(function() {
+        $('#confirmSave').on('show.bs.modal', function (e) {
+            var message = $(e.relatedTarget).attr('data-message');
+            var title = $(e.relatedTarget).attr('data-title');
+            var form = $(e.relatedTarget).closest('form');
+            $(this).find('.modal-body p').text(message);
+            $(this).find('.modal-title').text(title);
+            $(this).find('.modal-footer #confirm').data('form', form);
+        });
+        $('#confirmSave').find('.modal-footer #confirm').on('click', function(){
+            $(this).data('form').submit();
+        });
+    });
 </script>


### PR DESCRIPTION
…}) is executed. Wrapped code in $(document).ready(). If event is not registered, the $('#confirmSave').find('.modal-footer #confirm').on('click',) event will throw an exception because of $(this).data undefined.